### PR TITLE
http link to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Proxifier,SSTap等软件的免费代替品
 VPN的轻量级替代品,可以仅代理选定的应用进程。  
 比Proxifier,SSTap类软件更简单  
 
-http://www.kkcap.net
+https://www.kkcap.net
 
 ![jpg](https://www.kkcap.net/image/cnbanner.png)
 


### PR DESCRIPTION
The link to the www.kkcap.net on the readme.md is an http link, if you click it, an error will occur saying you are using http on https server. Therefore, this link should be modified to an https link.